### PR TITLE
0.1.8 - Handle 'Half' units and replace 'an or a' with 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ There are many other date/time helper functions available too make working with,
 #### Functions for converting additive time
 
 **[`convertAdditiveTimeToDate`](#convertadditivetimetodate)**\
-**[`processClearPhrases`](#processclearphrases)**\
-**[`processTimeUnits`](#processtimeunits)**
+**[`processTimeUnits`](#processtimeunits)**\
+**[`extractTimePartsAndUnits`](#extracttimepartsandunits)**
+
 
 ### Helper functions used throughout the package
 
@@ -233,27 +234,6 @@ This function converts additive time phrases to a date string in ISO format.
 
 - _string_: The date resulting from adding the time to current date, or an empty string if an invalid input was given.
 
-### processClearPhrases
-
-**Usage:**
-
-```typescript
-processClearPhrases(date: Date, phrase: string): Date;
-```
-
-**Description:**
-
-This function interprets clear phrases like 'tomorrow', 'next week', 'next month' and modifies the date accordingly.
-
-**Parameters:**
-
-- `date` (_Date_): The starting date.
-- `phrase` (_string_): The key phrase.
-
-**Returns:**
-
-- _Date_: The new date after adding the time specified by the phrase.
-
 ### processTimeUnits
 
 **Usage:**
@@ -302,6 +282,52 @@ This function converts word-based numerical values into actual numbers. It's cap
 **Exceptions:**
 
 If the function encounters an unrecognizable word that isn't a pre-defined number representation, it will throw an Error indicating 'Unknown number: ' followed by the unrecognized word.
+
+## Functions in `extract-time-parts-and-units.ts`
+
+This file contains two main functions and some helper functions used for parsing and extracting time units from time related strings. They provide functionality to parse user-friendly time phrases and generate the respective time parts.
+
+### extractTimePartsAndUnits
+
+**Usage:**
+
+```typescript
+extractTimePartsAndUnits(timeString: string): any[]|boolean;
+```
+
+**Description:**
+
+This function converts the time-related phrases in a string into a time specification. It replaces phrases such as "tomorrow", "next week", "next month", and "next year" with numeric representations and handles the details when the phrase includes "half". The function splits the time specification and maps each component separately. If the original string was invalid (or if no components are extracted) the function will return `false`, otherwise it returns an array of time parts.
+
+**Parameters:**
+
+- _timeString_:  A string containing time-related phrases.
+
+**Returns:**
+
+- _any[]|boolean_: An array of time parts, each of which is a string in the format "X unit", where X is a integer and unit is a time unit, such as "minute", "hour", "day", "week", "month" or "year". If no valid input is found, returns `false`.
+
+### handleHalf
+
+**Usage:**
+
+```typescript
+handleHalf(timeString: string): string|boolean;
+```
+
+**Description:**
+
+This function handles time-related phrases in a string that include "half". It identifies and replaces variations of "half", whether it appears as "half a X" or "X and a half" (where X is a time unit), with equivalent time in minutes. Returns false if the resulting time string is empty. Returns original time string if no matches or replacements were made.
+
+**Parameters:**
+
+- _timeString_:  A string containing time-related phrases, which may include variations of "half".
+
+**Returns:**
+
+- _string|boolean_: A time string with all "half" phrases replaced by equivalent time in minutes, or `false` if the resulting string is empty.
+
+
 
 ## Function in `extract-timezone.ts`
 
@@ -419,6 +445,7 @@ This function calculates the next date-time string based on the current time and
 **Returns:**
 
 - _string_: The next date-time as a string in the format "YYYY-MM-DD hh:mma". If no input is provided, it will return the current date-time string.
+
 
 # Credits
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "time-decoding-utils",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "time-decoding-utils",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "time-decoding-utils",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Utilities to help decode a variation of time and dates from input text",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,6 @@ export {
 //Functions for converting additive time
 export {
   convertAdditiveTimeToDate,
-  processClearPhrases,
   processTimeUnits,
 } from "./time-utils/convert-additive-time-to-date";
 
@@ -31,6 +30,7 @@ export {
   extractTimezoneAbbreviation,
 } from "./time-utils/helpers/extract-timezone";
 export { convertDateAndTimeToIso } from "./time-utils/helpers/convert-date-and-time-to-iso";
+export { extractTimePartsAndUnits } from "./time-utils/helpers/extract-time-parts-and-units";
 export {
   getCurrentDateString,
   getNextDateTime,

--- a/src/time-utils/convert-additive-time-to-date.ts
+++ b/src/time-utils/convert-additive-time-to-date.ts
@@ -25,6 +25,9 @@ export function processTimeUnits(
   timeData: string,
 ): [Date, boolean] {
   let [value, timeUnit] = timeData.trim().split(" ");
+  if(value == 'a' || value === 'an'){
+    value = 'one'
+  }
   if (
     !TIME_UNITS.includes(timeUnit) &&
     !TIME_UNITS.includes(timeUnit.slice(0, -1))

--- a/src/time-utils/helpers/extract-time-parts-and-units.ts
+++ b/src/time-utils/helpers/extract-time-parts-and-units.ts
@@ -1,0 +1,70 @@
+export function extractTimePartsAndUnits(timeString: string): any[]|boolean {
+    let invalidInput = false;
+    // Extract the time specification from the input string
+    timeString = timeString
+        .replace(/tomorrow/gi, "1 day")
+        .replace(/next week/gi, "1 week")
+        .replace(/next month/gi, "1 month")
+        .replace(/next year/gi, "1 year");
+    let timeStringWithHalfsReplaced = handleHalf(timeString);
+    if(typeof timeStringWithHalfsReplaced !== 'boolean'){
+        timeString = timeStringWithHalfsReplaced;
+    }
+    let timeSpecArray: RegExpMatchArray | null | undefined = timeString.match(
+        /(\w+|\d+)\s(year|month|week|day|hour|minute|second|and)s?/gi,
+    );
+
+    if (timeSpecArray === null) {
+        //@ts-ignore
+        timeSpecArray = [];
+    }
+
+    //@ts-expect-error This won't fail, I've already checked them above
+    const joinedTimeSpec = timeSpecArray.join(", ");
+    const timeSpec = joinedTimeSpec
+        .replace(/nextweek/gi, "next week")
+        .replace(/nextmonth/gi, "next month")
+        .replace(/nextyear/gi, "next year");
+
+    let timeParts = timeSpec.split(/[\s,]+and\s|,/).map((item) => item.trim());
+    if (timeParts.length === 1 && timeParts[0] === "") {
+        timeParts = [];
+        invalidInput = true;
+    }
+    if(invalidInput){
+        return false;
+    }
+
+    return timeParts
+}
+
+const timeUnitsToMinutes: {[key: string]: number} = {
+    "minute": 1,
+    "hour": 60,
+    "day": 24 * 60,
+    "week": 7 * 24 * 60,
+    "month": 30 * 24 * 60,
+    "year": 365 * 24 * 60
+};
+
+function replaceHalf (match: string, p1: string, p2:string) {
+    if(p1.startsWith('half')){
+        const value = timeUnitsToMinutes[p2] / 2;
+        return `${value} minutes`;
+    } else {
+        const value = 1.5 * timeUnitsToMinutes[p1];
+        return `${value} minutes`;
+    }
+}
+
+export function handleHalf(timeString: string): string|boolean{
+    let pattern = /(half a|half an)\s(year|month|week|day|hour|minute)s?/gi;
+    timeString = timeString.replace(pattern, replaceHalf);
+    pattern = /(year|month|week|day|hour|minute)\s(and a half)s?/gi;
+    timeString = timeString.replace(pattern, replaceHalf);
+    timeString = timeString.replace(/an (\d+) (\w+)/gi, '$1 $2').replace(/a (\d+) (\w+)/gi, '$1 $2');
+    if(timeString === ""){
+        return false;
+    }
+    return timeString
+}

--- a/tests/time-utils/convert-additive-time-to-date.test.ts
+++ b/tests/time-utils/convert-additive-time-to-date.test.ts
@@ -1,7 +1,6 @@
 import { add, addDays, addMonths, addWeeks } from "date-fns";
 import {
   convertAdditiveTimeToDate,
-  processClearPhrases,
   processTimeUnits,
 } from "../../src";
 import { advanceTo, clear } from "jest-date-mock";
@@ -44,6 +43,12 @@ describe("convertAdditiveTimeToDate Correctly generates the right date", () => {
   it("Test example: an hour", () => {
     expect(convertAdditiveTimeToDate("an hour")).toBe(
         add(currentTime, { ["hours"]: Number("1") }).toISOString(),
+    );
+  });
+
+  it("Test example: an hour and a half", () => {
+    expect(convertAdditiveTimeToDate("an hour and a half")).toBe(
+        add(currentTime, { ["minutes"]: Number("90") }).toISOString(),
     );
   });
 
@@ -153,35 +158,6 @@ describe("convertAdditiveTimeToDate Correctly generates the right date from larg
     const input = "I will meet you tomorrow at 9pm";
     const expected = add(currentTime, { ["days"]: Number("1") });
     expect(convertAdditiveTimeToDate(input)).toBe(expected.toISOString());
-  });
-});
-
-describe("processClearPhrases tests", () => {
-  it("should add 1 day for 'tomorrow'", () => {
-    const currentTime = new Date();
-    const expectedResult = addDays(currentTime, 1);
-    const result = processClearPhrases(currentTime, "tomorrow");
-    expect(result).toEqual(expectedResult);
-  });
-
-  it("should add 1 week for 'next week'", () => {
-    const currentTime = new Date();
-    const expectedResult = addWeeks(currentTime, 1);
-    const result = processClearPhrases(currentTime, "next week");
-    expect(result).toEqual(expectedResult);
-  });
-
-  it("should add 1 month for 'next month'", () => {
-    const currentTime = new Date();
-    const expectedResult = addMonths(currentTime, 1);
-    const result = processClearPhrases(currentTime, "next month");
-    expect(result).toEqual(expectedResult);
-  });
-
-  it("should return the same date for unknown input", () => {
-    const currentTime = new Date();
-    const result = processClearPhrases(currentTime, "yesterday");
-    expect(result).toEqual(currentTime);
   });
 });
 

--- a/tests/time-utils/convert-additive-time-to-date.test.ts
+++ b/tests/time-utils/convert-additive-time-to-date.test.ts
@@ -35,6 +35,18 @@ describe("convertAdditiveTimeToDate Correctly generates the right date", () => {
     );
   });
 
+  it("Test example: a year", () => {
+    expect(convertAdditiveTimeToDate("a year")).toBe(
+        add(currentTime, { ["years"]: Number("1") }).toISOString(),
+    );
+  });
+
+  it("Test example: an hour", () => {
+    expect(convertAdditiveTimeToDate("an hour")).toBe(
+        add(currentTime, { ["hours"]: Number("1") }).toISOString(),
+    );
+  });
+
   it("Test example: three hours and 20 minutes", () => {
     expect(convertAdditiveTimeToDate("three hours and 20 minutes")).toBe(
       add(currentTime, {

--- a/tests/time-utils/extract-time-from-input.test.ts
+++ b/tests/time-utils/extract-time-from-input.test.ts
@@ -58,6 +58,12 @@ describe("extractTimeFromInput Test Suite", () => {
     expect(extractTimeFromInput(input)).toEqual(expected);
   });
 
+  it('should return date for "12/24/2025 at 12" input', () => {
+    const input = "12/24/2025 at 12";
+    const expected = "2025-12-24T18:00:00.000Z";
+    expect(extractTimeFromInput(input)).toEqual(expected);
+  });
+
   it('should return date for "07/24/2025 at 2PM" input', () => {
     const input = "07/24/2025 at 2PM";
     const expected = "2025-07-24T19:00:00.000Z";

--- a/tests/time-utils/extract-time-from-input.test.ts
+++ b/tests/time-utils/extract-time-from-input.test.ts
@@ -16,6 +16,18 @@ describe("extractTimeFromInput Test Suite", () => {
     expect(extractTimeFromInput(input)).toEqual(expected);
   });
 
+  it('should return date for "a month and a half" input', () => {
+    const input = "a month and a half";
+    const expected = "2024-03-01T18:00:00.000Z";
+    expect(extractTimeFromInput(input)).toEqual(expected);
+  });
+
+  it('should return date for "a month and a day and a half" input', () => {
+    const input = "a month and a day and a half";
+    const expected = "2024-02-18T06:00:00.000Z";
+    expect(extractTimeFromInput(input)).toEqual(expected);
+  });
+
   it('should return date for "1 hour" input', () => {
     const input = "1 hour";
     const expected = "2024-01-16T19:00:00.000Z";

--- a/tests/time-utils/helpers/extract-time-parts-and-units.test.ts
+++ b/tests/time-utils/helpers/extract-time-parts-and-units.test.ts
@@ -1,0 +1,150 @@
+import {extractTimePartsAndUnits} from "../../../src";
+import {handleHalf} from "../../../src/time-utils/helpers/extract-time-parts-and-units";
+describe("extractTimePartsAndUnits tests", () => {
+  const runTest = (input: string, expected: string[]|boolean) => {
+    expect(extractTimePartsAndUnits(input)).toEqual(expected);
+  };
+
+  it("Input: 1 day", () => {
+    const input = "1 day";
+    const expected = ["1 day"];
+    runTest(input, expected);
+  });
+
+  it("Input: 1 day 5 years 9 hours 3 minutes", () => {
+    const input = "1 day 5 years 9 hours 3 minutes";
+    const expected = [
+      "1 day",
+      "5 years",
+      "9 hours",
+      "3 minutes"
+    ];
+    runTest(input, expected);
+  });
+  it("Input: 2 days, 6 months and 4 hours", () => {
+    const input = "2 days, 6 months and 4 hours";
+    const expected = [
+      "2 days",
+      "6 months",
+      "4 hours",
+    ];
+    runTest(input, expected);
+  });
+
+  it("Input: tomorrow", () => {
+    const input = "tomorrow";
+    const expected = ["1 day"];
+    runTest(input, expected);
+  });
+
+  it("Input: next year 10 seconds", () => {
+    const input = "next year 10 seconds";
+    const expected = [
+      "1 year",
+      "10 seconds",
+    ];
+    runTest(input, expected);
+  });
+
+  it("Input: an hour and a half", () => {
+    const input = "an hour and a half";
+    const expected = [
+      "90 minutes",
+    ];
+    runTest(input, expected);
+  });
+
+  it("Input: half an hour", () => {
+    const input = "half an hour";
+    const expected = [
+      "30 minutes",
+    ];
+    runTest(input, expected);
+  });
+
+  it("Input: half a day", () => {
+    const input = "half a day";
+    const expected = [
+      "720 minutes",
+    ];
+    runTest(input, expected);
+  });
+
+  it("Input: 2 years and half a day", () => {
+    const input = "2 years and half a day";
+    const expected = [
+        "2 years",
+      "720 minutes",
+    ];
+    runTest(input, expected);
+  });
+
+  it("Input: a week and a half", () => {
+    const input = "a week and a half";
+    const expected = [
+      "15120 minutes"
+    ];
+    runTest(input, expected);
+  });
+
+  it("Input: next month", () => {
+    const input = "next month";
+    const expected = ["1 month"];
+    runTest(input, expected);
+  });
+
+  it("Input: empty string", () => {
+    const input = "";
+    const expected = false;
+    runTest(input, expected);
+  });
+
+  it("Input: invalid string", () => {
+    const input = "invalid string";
+    const expected = false;
+    runTest(input, expected);
+  });
+});
+describe("handleHalf tests", () => {
+  const runTest = (input: string, expected: string|boolean) => {
+    expect(handleHalf(input)).toEqual(expected);
+  };
+
+  it("Input: an hour and a half", () => {
+    const input = "an hour and a half";
+    const expected = "90 minutes";
+    runTest(input, expected);
+  });
+
+  it("Input: half an hour", () => {
+    const input = "half an hour";
+    const expected = "30 minutes";
+    runTest(input, expected);
+  });
+
+  it("Input: half a day", () => {
+    const input = "half a day";
+    const expected = "720 minutes"
+    runTest(input, expected);
+  });
+
+  it("Input: a week and a half", () => {
+    const input = "a week and a half";
+    const expected = "15120 minutes";
+
+    runTest(input, expected);
+  });
+
+
+  it("Input: empty string", () => {
+    const input = "";
+    const expected = false;
+    runTest(input, expected);
+  });
+
+  it("Input: invalid string", () => {
+    const input = "invalid string";
+    const expected = "invalid string";
+    runTest(input, expected);
+  });
+});


### PR DESCRIPTION
I've pulled out the code that finds the time units in the string to a separate function and file `extractTimePartsAndUnits` which also handles replacing `an hour` or `a year` with `1 hour` and `1 year` respectively.
I've also added handling for `half a {unit}` and `{unit} and a half` which just gets added on as minutes because that was the easiest way to handle it.

Closes #5
Closes #7
Closes #2